### PR TITLE
Add a custmor transcoder to support couchbase raw binary format

### DIFF
--- a/handlers/couchbase/couchbase.go
+++ b/handlers/couchbase/couchbase.go
@@ -40,7 +40,7 @@ func (t CustomRawBinaryTranscoder) Decode(bytes []byte, flags uint32, out interf
 		*typedOut = string(bytes)
 		return nil
 	default:
-		return errors.New("Custom raw binary format must be encoded in a byte array or interface")
+		return errors.New("custom raw binary format must be encoded in a byte array or string")
 	}
 }
 

--- a/handlers/couchbase/couchbase.go
+++ b/handlers/couchbase/couchbase.go
@@ -26,6 +26,44 @@ type couchbaseClient struct {
 	client *gocb.Bucket
 }
 
+const customRawBinaryTypecode = 0x4352544f
+
+type CustomRawBinaryTranscoder struct {
+}
+
+func (t CustomRawBinaryTranscoder) Decode(bytes []byte, flags uint32, out interface{}) error {
+	switch typedOut := out.(type) {
+	case *[]byte:
+		*typedOut = bytes
+		return nil
+	case *string:
+		*typedOut = string(bytes)
+		return nil
+	default:
+		return errors.New("Custom raw binary format must be encoded in a byte array or interface")
+	}
+}
+
+func (t CustomRawBinaryTranscoder) Encode(value interface{}) ([]byte, uint32, error) {
+	var bytes []byte
+
+	switch typeValue := value.(type) {
+	case []byte:
+		bytes = typeValue
+	case *[]byte:
+		bytes = *typeValue
+	case string:
+		bytes = []byte(typeValue)
+	case *string:
+		bytes = []byte(*typeValue)
+	default:
+		return nil, customRawBinaryTypecode,
+			errors.New("raw binary custom format must be encoded from a byte array or interface")
+	}
+
+	return bytes, customRawBinaryTypecode, nil
+}
+
 func (c *couchbaseClient) close() error {
 	return c.client.Close()
 }
@@ -52,6 +90,7 @@ func NewHandler(clusterAddr string, bucketName string) (Handler, error) {
 	if err != nil {
 		return Handler{}, err
 	}
+	bucket.SetTranscoder(&CustomRawBinaryTranscoder{})
 
 	client := couchbaseClient{client: bucket}
 

--- a/handlers/couchbase/couchbase_test.go
+++ b/handlers/couchbase/couchbase_test.go
@@ -2,6 +2,8 @@ package couchbase
 
 import (
 	"errors"
+	"fmt"
+	"math/rand"
 	"testing"
 
 	"github.com/netflix/rend/common"
@@ -139,5 +141,51 @@ func TestMalformattedGetRequestReturnError(t *testing.T) {
 		t.Errorf("Unexpected errors are not handled")
 	case <-errOut:
 		return
+	}
+}
+
+// checks if two bytes arrays are the same
+func testEq(a, b []byte) bool {
+	// If one is nil, the other must also be nil.
+	if (a == nil) != (b == nil) {
+		return false;
+	} else if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestCustomRawBinaryTranscoderDecodeToByteArray(t *testing.T) {
+	transcoder := CustomRawBinaryTranscoder{}
+	input := "ABC€"
+	in := []byte(input)
+	flags := rand.Uint32(); //random uint32
+	var out []byte
+	err := transcoder.Decode(in, flags, &out)
+
+	if err != nil {
+		t.Errorf("Error is \"%v\"; want nil", err)
+	} else if !testEq(in, out) {
+		t.Errorf("out is %v; want %v", out, in)
+	}
+}
+
+func TestCustomRawBinaryTranscoderDecodeToString(t *testing.T) {
+	transcoder := CustomRawBinaryTranscoder{}
+	input := "ABC€"
+	in := []byte(input)
+	flags := rand.Uint32(); //random uint32
+	var out string
+	err := transcoder.Decode(in, flags, &out)
+
+	if err != nil {
+		t.Errorf("Error is \"%v\"; want nil", err)
+	} else if input != fmt.Sprintf("%v", out) {
+		t.Errorf("out is \"%v\"; want \"%v\"", out, input)
 	}
 }


### PR DESCRIPTION
 - It seems that when we retrieve binary encoded documents from
   couchbase v4.x using the default transcoder, some flags
   are causing the default trancoder to infer that there is
   some kind of compression involved. This causes error.
 - This custom trancoder is used to bypass flags checking.

Signed-off-by: Jean-Francois Weber-Marx <jfwm@hotmail.com>