### PR TITLE
Move to a dedicated memaerospike proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 AS builder
+FROM golang:1.15 AS builder
 
 
 LABEL maintener="nosql-team@criteo.com"

--- a/app/memaerospike.go
+++ b/app/memaerospike.go
@@ -30,6 +30,7 @@ func initAeroDefaultConfig() {
 	viper.SetDefault("ClusterName", "aerospike-nvme-bench-3-nodes")
 	viper.SetDefault("Bucket", "persisted")
 	viper.SetDefault("NbConcurrentRequests", 500)
+	viper.SetDefault("MemcachedMaxBufferedSetRequests", 80*1000)
 	viper.SetDefault("GracefulShutdownWaitTimeInSec", 10*60)
 }
 
@@ -61,9 +62,6 @@ func main() {
 
 	// http debug and metrics endpoint
 	go http.ListenAndServe(viper.GetString("InternalMetricsListenAddress"), nil)
-
-	// metrics output prefix
-	// metrics.SetPrefix("memandra_")
 
 	var h1 handlers.HandlerConst
 	var h2 handlers.HandlerConst

--- a/app/memaerospike.go
+++ b/app/memaerospike.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/netflix/rend/consul"
+	"github.com/netflix/rend/handlers/aerospike"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime/debug"
+	"syscall"
+	"time"
+
+	"github.com/netflix/rend/handlers"
+	"github.com/netflix/rend/orcas"
+	"github.com/netflix/rend/protocol"
+	"github.com/netflix/rend/protocol/binprot"
+	"github.com/netflix/rend/server"
+	"github.com/spf13/viper"
+)
+
+func initAeroDefaultConfig() {
+	log.Println("Initializing configuration")
+	viper.SetDefault("ListenPort", 11221)
+	viper.SetDefault("InternalMetricsListenAddress", ":11299")
+	viper.SetDefault("ConsulAddr", "localhost:8500")
+	viper.SetDefault("ClusterName", "aerospike-nvme-bench-3-nodes")
+	viper.SetDefault("Bucket", "persisted")
+	viper.SetDefault("NbConcurrentRequests", 500)
+	viper.SetDefault("GracefulShutdownWaitTimeInSec", 10*60)
+}
+
+func main() {
+	if _, set := os.LookupEnv("GOGC"); !set {
+		debug.SetGCPercent(100)
+	}
+
+	var configPath = flag.String("configFilePath", "", "File path where to find the config.yaml of the application")
+	flag.Parse()
+
+	initAeroDefaultConfig()
+	if *configPath != "" {
+		dir, fileName := filepath.Split(*configPath)
+		viper.SetConfigName(fileName)
+		viper.SetConfigType("yaml")
+		viper.AddConfigPath(dir)
+	} else {
+		viper.SetConfigName("config")
+		viper.SetConfigType("yaml")
+		viper.AddConfigPath(".")
+		viper.AddConfigPath("/etc/memaerospike/")
+	}
+
+	err := viper.ReadInConfig() // Find and read the config file
+	if err != nil {             // Handle errors reading the config file
+		panic(fmt.Errorf("Fatal error config file: %s \n", err))
+	}
+
+	// http debug and metrics endpoint
+	go http.ListenAndServe(viper.GetString("InternalMetricsListenAddress"), nil)
+
+	// metrics output prefix
+	// metrics.SetPrefix("memandra_")
+
+	var h1 handlers.HandlerConst
+	var h2 handlers.HandlerConst
+
+	// get nodes from consul
+	consulAddr := viper.GetString("ConsulAddr")
+	clusterName := viper.GetString("ClusterName")
+	instances, err := consul.GetNodes(clusterName, consulAddr, "")
+	log.Printf("Discovered for %s: %s", clusterName, instances)
+	if err != nil {
+		log.Fatalf("Error: couldn't fetch service from Consul: %s", err)
+	}
+
+	// Init aerospike connection
+	aerospikeHandler, err := aerospike.NewHandler(instances[0], viper.GetString("Bucket"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// L1Only MODE
+	h1 = func() (handlers.Handler, error) {
+		return aerospikeHandler, nil
+	}
+	h2 = handlers.NilHandler
+
+	l := server.TCPListener(viper.GetInt("ListenPort"))
+	protocols := []protocol.Components{binprot.Components}
+
+	// Graceful stop
+	var gracefulStop = make(chan os.Signal)
+	signal.Notify(gracefulStop, syscall.SIGTERM)
+	signal.Notify(gracefulStop, syscall.SIGKILL)
+	signal.Notify(gracefulStop, syscall.SIGINT)
+	go func() {
+		_ = <-gracefulStop
+		log.Println("[INFO] Gracefully stopping Memandra server")
+		go func() {
+			waitTime := viper.GetDuration("GracefulShutdownWaitTimeInSec") * time.Second
+			log.Println("[INFO] Waiting", waitTime, "for aerospike executors to shutdown")
+			time.Sleep(waitTime)
+			log.Println("[INFO] Forcing exit as", waitTime, "passed")
+			os.Exit(0)
+		}()
+
+		aerospikeHandler.Shutdown()
+		os.Exit(0)
+	}()
+
+	server.ListenAndServe(l, protocols, server.Default, orcas.L1Only, h1, h2)
+}

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,5 @@
-ListenPort: 11221
+ListenPort: "11220"
 InternalMetricsListenAddress: ":11299"
-CassandraHostname: "cassandra-cstars999.service.consul.preprod.crto.in"
-CassandraKeyspace: "kvstore"
-CassandraBucket: "bucket1"
-CassandraNbConcurrentRequests: 1
-MemcachedMaxBufferedSetRequests: 80000
+ConsulAddr: "consul-relay.service.par.consul.preprod.crto.in:8500"
+ClusterName: "aerospike-nvme-bench-3-nodes"
+NbConcurrentRequests: 1

--- a/handlers/aerospike/aerospike.go
+++ b/handlers/aerospike/aerospike.go
@@ -50,9 +50,9 @@ func (h Handler) Set(cmd common.SetRequest) error {
 	if err != nil {
 		return err
 	}
-	data := aero.BinMap{"value": cmd.Data}
+	bin := aero.NewBin("value", cmd.Data)
 	policy := aero.NewWritePolicy(0, cmd.Exptime)
-	return h.client.Put(policy, key, data)
+	return h.client.PutBins(policy, key, bin)
 }
 
 func (h Handler) Get(cmd common.GetRequest) (<-chan common.GetResponse, <-chan error) {

--- a/handlers/aerospike/aerospike.go
+++ b/handlers/aerospike/aerospike.go
@@ -2,8 +2,14 @@ package aerospike
 
 import (
 	"errors"
+	"github.com/netflix/rend/metrics"
+	"github.com/netflix/rend/timer"
+	"github.com/spf13/viper"
+	"log"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	aero "github.com/aerospike/aerospike-client-go"
 	"github.com/netflix/rend/common"
@@ -14,11 +20,34 @@ var (
 	errNotFound = "Key not found"
 )
 
+// TODO: implement Replace
+
 type Handler struct {
-	client    *aero.Client
-	namespace string
-	set       string
+	client        *aero.Client
+	namespace     string
+	set           string
+	setbuffer     chan AerospikeGetSet
+	executors     sync.WaitGroup
+	isShutingDown uint32
 }
+
+type AerospikeGetSet struct {
+	Get      bool
+	cmdGet   *common.GetRequest
+	cmdSet   *common.SetRequest
+	dataOut  chan common.GetResponse
+	errorOut chan error
+}
+
+// Aerospike metrics
+var (
+	HistSetEnqueueLatencies = metrics.AddHistogram("set_enqueue_latencies", false, nil)
+	HistGetEnqueueLatencies = metrics.AddHistogram("get_enqueue_latencies", false, nil)
+	HistSetLatencies        = metrics.AddHistogram("set_aerospike_latencies", false, nil)
+	HistGetLatencies        = metrics.AddHistogram("get_aerospike_latencies", false, nil)
+	HistReplaceLatencies    = metrics.AddHistogram("replace_aerospike_latencies", false, nil)
+	HistDeleteLatencies     = metrics.AddHistogram("delete_aerospike_latencies", false, nil)
+)
 
 func NewHandler(clusterAddr string, bucketName string) (Handler, error) {
 	addr := strings.Split(clusterAddr, ":")
@@ -26,16 +55,33 @@ func NewHandler(clusterAddr string, bucketName string) (Handler, error) {
 	if err != nil {
 		return Handler{}, err
 	}
-	//clientPolicy := aero.NewClientPolicy()
-	//clientPolicy.MinConnectionsPerNode = 2
-	//clientPolicy.ConnectionQueueSize = 4096
-	//client, err := aero.NewClientWithPolicy(clientPolicy, addr[0], port)
-	client, err := aero.NewClient(addr[0], port)
+	clientPolicy := aero.NewClientPolicy()
+	clientPolicy.ConnectionQueueSize = 1024
+	client, err := aero.NewClientWithPolicy(clientPolicy, addr[0], port)
+	//client, err := aero.NewClient(addr[0], port)
 	if err != nil {
 		return Handler{}, err
 	}
 
-	return Handler{client: client, namespace: bucketName, set: "rend"}, nil
+	aerospikeHandler := Handler{
+		client:    client,
+		namespace: bucketName,
+		set:       "rend",
+
+		// Statements
+		setbuffer: make(chan AerospikeGetSet, viper.GetInt("MemcachedMaxBufferedSetRequests")),
+
+		// Synchronization
+		isShutingDown: 0,
+		executors:     sync.WaitGroup{},
+	}
+
+	// Spawn go-routines that will fan out memcached requests to Aerospike
+	for i := 1; i <= viper.GetInt("NbConcurrentRequests"); i++ {
+		go aerospikeHandler.spawnExecutor()
+	}
+
+	return aerospikeHandler, nil
 }
 
 func NewHandlerConst(clusterAddr string, bucketName string) handlers.HandlerConst {
@@ -44,99 +90,162 @@ func NewHandlerConst(clusterAddr string, bucketName string) handlers.HandlerCons
 	}
 }
 
+// We read from the channel from N executor/goroutine in order to propagate the writes
+func (h Handler) spawnExecutor() {
+	h.executors.Add(1)
+
+	for item := range h.setbuffer {
+		if item.Get {
+			h.HandleGet(item)
+		} else {
+			h.HandleSet(item)
+		}
+	}
+
+	h.executors.Done()
+}
+
+func (h Handler) HandleSet(item AerospikeGetSet) {
+	start := timer.Now()
+	key, err := aero.NewKey(h.namespace, h.set, item.cmdSet.Key)
+	if err != nil {
+		log.Println("[ERROR] NewKey get creation failed", err)
+		return
+	}
+
+	bin := aero.NewBin("value", item.cmdSet.Data)
+	err = h.client.PutBins(aero.NewWritePolicy(0, item.cmdSet.Exptime), key, bin)
+	if err != nil {
+		log.Println("[ERROR] Aerospike put returned an error. ", item.cmdSet.Key, err)
+	}
+	metrics.ObserveHist(HistSetLatencies, timer.Since(start))
+}
+
+func (h Handler) HandleGet(item AerospikeGetSet) {
+	defer close(item.errorOut)
+	defer close(item.dataOut)
+
+	start := timer.Now()
+	if len(item.cmdGet.Opaques) != len(item.cmdGet.Keys) || len(item.cmdGet.Quiet) != len(item.cmdGet.Keys) {
+		item.errorOut <- errors.New("Received different number of Keys, Opaques and Quiet")
+		return
+	}
+	for i, key := range item.cmdGet.Keys {
+		miss := false
+		aeroKey, err := aero.NewKey(h.namespace, h.set, key)
+		if err != nil {
+			miss = true
+			log.Println("[ERROR] NewKey get creation failed", err)
+			item.errorOut <- err
+			break
+		}
+		record, err := h.client.Get(nil, aeroKey, "value")
+		data := []byte{}
+		if err != nil {
+			if err.Error() == errNotFound {
+				miss = true
+			} else {
+				miss = true
+				log.Println("[ERROR] Aerospike get returned an error. ", err)
+				item.errorOut <- err
+				break
+			}
+		} else {
+			rawData, ok := record.Bins["value"]
+			if !ok {
+				miss = true
+				log.Println("[ERROR] Bin retrieved from Aerospike was not found")
+				item.errorOut <- errors.New("Bin retrieved from Aerospike was not found")
+				break
+			}
+			data, ok = rawData.([]byte)
+			if !ok {
+				miss = true
+				log.Println("[ERROR] Data retrieved from AeroSpike was corrupted")
+				item.errorOut <- errors.New("Data retrieved from AeroSpike was corrupted")
+				break
+			}
+		}
+		item.dataOut <- common.GetResponse{Key: key, Data: data, Opaque: item.cmdGet.Opaques[i], Flags: 0, Miss: miss, Quiet: item.cmdGet.Quiet[i]}
+		metrics.ObserveHist(HistGetLatencies, timer.Since(start))
+	}
+}
+
 func (h Handler) Close() error {
 	return nil
 }
 
 func (h Handler) Shutdown() error {
+	atomic.AddUint32(&h.isShutingDown, 1)
 	h.client.Close()
 	return nil
 }
 
-func (h Handler) Set(cmd common.SetRequest) error {
-	errorOut := make(chan error)
-
-	go h.realHandleSet(cmd, errorOut)
-
-	tErr, ok := <-errorOut
-	if !ok {
-		return nil
-	} else {
-		return tErr
-	}
+func (h *Handler) IsShutingDown() bool {
+	return atomic.LoadUint32(&h.isShutingDown) > 0
 }
 
-func (h *Handler) realHandleSet(cmd common.SetRequest, errorOut chan error) {
-	defer close(errorOut)
-
-	key, err := aero.NewKey(h.namespace, h.set, cmd.Key)
-	if err != nil {
-		errorOut <- err
+func (h Handler) Set(cmd common.SetRequest) error {
+	if h.IsShutingDown() {
+		return common.ErrItemNotStored
 	}
-	bin := aero.NewBin("value", cmd.Data)
-	policy := aero.NewWritePolicy(0, cmd.Exptime)
-	errorOut <- h.client.PutBins(policy, key, bin)
 
+	start := timer.Now()
+	h.setbuffer <- AerospikeGetSet{
+		Get:    false,
+		cmdSet: &cmd,
+	}
+	metrics.ObserveHist(HistSetEnqueueLatencies, timer.Since(start))
+
+	return nil
 }
 
 func (h Handler) Get(cmd common.GetRequest) (<-chan common.GetResponse, <-chan error) {
 	dataOut := make(chan common.GetResponse)
 	errorOut := make(chan error)
 
-	go h.realHandleGet(cmd, dataOut, errorOut)
+	if h.IsShutingDown() {
+		errorOut <- common.ErrItemNotStored
+	} else {
+		start := timer.Now()
+		h.setbuffer <- AerospikeGetSet{
+			Get:      true,
+			cmdGet:   &cmd,
+			dataOut:  dataOut,
+			errorOut: errorOut,
+		}
+		metrics.ObserveHist(HistGetEnqueueLatencies, timer.Since(start))
+	}
+
 	return dataOut, errorOut
-}
-
-func (h *Handler) realHandleGet(cmd common.GetRequest, dataOut chan common.GetResponse, errorOut chan error) {
-	defer close(errorOut)
-	defer close(dataOut)
-
-	if len(cmd.Opaques) != len(cmd.Keys) || len(cmd.Quiet) != len(cmd.Keys) {
-		errorOut <- errors.New("Received different number of Keys, Opaques and Quiet")
-		return
-	}
-	for i, key := range cmd.Keys {
-		aeroKey, err := aero.NewKey(h.namespace, h.set, key)
-		if err != nil {
-			errorOut <- err
-			break
-		}
-		record, err := h.client.Get(nil, aeroKey, "value")
-		miss := false
-		data := []byte{}
-		if err != nil {
-			if err.Error() == errNotFound {
-				miss = true
-			} else {
-				errorOut <- err
-				break
-			}
-		} else {
-			rawData, ok := record.Bins["value"]
-			if !ok {
-				errorOut <- errors.New("Bin retrieved from Aerospike was not found")
-				break
-			}
-			data, ok = rawData.([]byte)
-			if !ok {
-				errorOut <- errors.New("Data retrieved from AeroSpike was corrupted")
-				break
-			}
-		}
-		dataOut <- common.GetResponse{Key: key, Data: data, Opaque: cmd.Opaques[i], Flags: 0, Miss: miss, Quiet: cmd.Quiet[i]}
-	}
-
 }
 
 func (h Handler) GetE(cmd common.GetRequest) (<-chan common.GetEResponse, <-chan error) {
 	return nil, nil
 }
 func (h Handler) GAT(cmd common.GATRequest) (common.GetResponse, error) {
-	return common.GetResponse{}, nil
+	return common.GetResponse{
+		Miss:   true,
+		Opaque: cmd.Opaque,
+		Key:    cmd.Key,
+	}, nil
 }
+
 func (h Handler) Delete(cmd common.DeleteRequest) error {
+	start := timer.Now()
+	aeroKey, err := aero.NewKey(h.namespace, h.set, cmd.Key)
+	if err != nil {
+		log.Println("[ERROR] NewKey get creation failed", err)
+		return err
+	}
+	_, err = h.client.Delete(nil, aeroKey)
+	metrics.ObserveHist(HistDeleteLatencies, timer.Since(start))
+	if err != nil {
+		return err
+	}
 	return nil
 }
+
 func (h Handler) Touch(cmd common.TouchRequest) error {
 	return nil
 }


### PR DESCRIPTION
Create only one aerospike client for all connections
Use a goroutine pool for get and set instead of creating goroutine for each gt and set

Leads to throughput increase around 40%
Leads to beter latency around 25% (when memtier is performed with more threads/clients)

Implement delete and replace